### PR TITLE
Support for DSN-less configurations

### DIFF
--- a/lib/rdbi/driver/odbc.rb
+++ b/lib/rdbi/driver/odbc.rb
@@ -49,12 +49,17 @@ class RDBI::Driver::ODBC < RDBI::Driver
     def initialize(*args)
       super *args
 
-      database = @connect_args[:database] || @connect_args[:dbname] ||
+      database     = @connect_args[:database] || @connect_args[:dbname] ||
         @connect_args[:db]
-      username = @connect_args[:username] || @connect_args[:user]
-      password = @connect_args[:password] || @connect_args[:pass]
+      username     = @connect_args[:username] || @connect_args[:user]
+      password     = @connect_args[:password] || @connect_args[:pass]
 
-      @handle = ::ODBC.connect(database, username, password)
+      if @connect_args[:dynamic]
+        @connect_args.delete(:dynamic)
+        @handle = dsnless_driver_handle(@connect_args)
+      else
+        @handle = ::ODBC.connect(database, username, password)
+      end
 
       self.database_name = @handle.get_info("SQL_DATABASE_NAME")
     end
@@ -116,6 +121,15 @@ class RDBI::Driver::ODBC < RDBI::Driver
       else
         "'#{item.to_s}'"
       end
+    end
+
+    private
+
+    def dsnless_driver_handle(attributes = {})
+      driver      = ::ODBC::Driver.new
+      driver.name = 'DSN-less Driver'
+      attributes.each {|key, value| driver.attrs[key.to_s] = value unless key == :dynamic }
+      ::ODBC::Database.new.drvconnect(driver)
     end
   end
 

--- a/lib/rdbi/driver/odbc.rb
+++ b/lib/rdbi/driver/odbc.rb
@@ -128,7 +128,7 @@ class RDBI::Driver::ODBC < RDBI::Driver
     def dsnless_driver_handle(attributes = {})
       driver      = ::ODBC::Driver.new
       driver.name = 'DSN-less Driver'
-      attributes.each {|key, value| driver.attrs[key.to_s] = value unless key == :dynamic }
+      attributes.each {|key, value| driver.attrs[key.to_s] = value }
       ::ODBC::Database.new.drvconnect(driver)
     end
   end


### PR DESCRIPTION
Shane (@semmons99),

I am in the process of migrating some client code from using the dbi / dbd-odbc gems to the rdbi / rdbi-driver-odbc gem. I am dependent on the ability of using DSN-less configurations for my client's work.  The former dbd-odbc gem supported configurations that don't use DSNs.

This pull request allows for the ability to create a connection by proxying to the ODBC::Driver to specify a new driver on the fly.

I decided to use the current mechanism of a hash to pass the attributes through.  If you specify :dynamic as a key in the attributes hash, it was flip over to the DSN-less configuration.  If you can think of a better way to support this API, I'm open to other possibilities too.

For reference, see the ruby-odbc documents on ODBC::Driver: http://www.ch-werner.de/rubyodbc/odbc.html#ODBC::Driver

Thanks for your understanding.  Let me know if you have any questions.
