### PR TITLE
update dependencies to build and install on Debian Buster

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,3 +45,7 @@ desc "Validate the gemspec"
 task :gemspec do
   gemspec.validate
 end
+
+task :default => :gem do
+  puts "generated latest version"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,8 @@ rescue LoadError
 end
 
 begin
-  require 'rake/gempackagetask'
-  Rake::GemPackageTask.new(gemspec) do |pkg|
+  require 'rubygems/package_task'
+  Gem::PackageTask.new(gemspec) do |pkg|
     pkg.gem_spec = gemspec
   end
   task :gem => :gemspec

--- a/lib/rdbi/driver/odbc.rb
+++ b/lib/rdbi/driver/odbc.rb
@@ -1,6 +1,6 @@
 require 'rdbi'
 require 'rubygems'
-gem 'ruby-odbc', '= 0.99994'
+gem 'ruby-odbc', '>= 0.99994'
 require 'odbc'
 require 'time'
 

--- a/rdbi-driver-odbc.gemspec
+++ b/rdbi-driver-odbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "rdbi-driver-odbc"
-  s.version     = "0.1.2"
+  s.version     = "0.1.2.77"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Shane Emmons"]
   s.email       = "semmons99@gmail.com"

--- a/rdbi-driver-odbc.gemspec
+++ b/rdbi-driver-odbc.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "rdbi",      "~> 1"
-  s.add_dependency "ruby-odbc", "= 0.99994"
+  s.add_dependency "ruby-odbc", ">= 0.99994"
 
   s.add_development_dependency "rdbi-dbrc", "~> 0.1"
   s.add_development_dependency "rspec",     "~> 2"


### PR DESCRIPTION
I don't have the first clue what I'm doing but this series of commits got me something that at least installed on Debian Buster, where I've been struggling against what I now realize is a regression in the underlying ruby-odbc library.  I can and will go back to using ruby-dbi after solving that, so I'm not attached to these changes, but I notice that at least two other forks were fighting similar issues, so thought it worth making that visible in the master.